### PR TITLE
Trello#999 added 'dev' env capability to imageEndpoint

### DIFF
--- a/yesticket/src/helpers/image_api.php
+++ b/yesticket/src/helpers/image_api.php
@@ -56,13 +56,13 @@ class ImageApi
   /**
    * Get Event image from yesticket for given $event_id
    * 
-   * @param int $event_id
+   * @param WP_REST_Request $wp_request
    * 
    * @return CachedImage|WP_Error image (using cache) or ERROR. Error's data will be the resource URL.
    */
-  public function getEventImage($event_id)
+  public function getEventImage($wp_request)
   {
-    $yesTicketImageUrl = $this->getYesTicketUrlOfImage($event_id);
+    $yesTicketImageUrl = $this->getYesTicketUrlOfImage($wp_request);
     $image = $this->cache->getFromCacheOrFresh($yesTicketImageUrl, function ($get_url) {
       return $this->_getEventImage($get_url);
     });
@@ -182,13 +182,19 @@ class ImageApi
   }
 
   /**
-   * Takes an event_id and returns the corresponding event image's URL on the yesticket.org platform
+   * Returns the corresponding event image's URL on the yesticket.org platform
    * 
-   * @param number $event_id ID of event
+   * @param WP_REST_Request $wp_request
+   * 
    * @return string image url
    */
-  public function getYesTicketUrlOfImage($event_id)
+  public function getYesTicketUrlOfImage($wp_request)
   {
-    return "https://www.yesticket.org/picture.php?event=" . $event_id;
+    $event_id = $wp_request['event_id'];
+    $env_add = '';
+    if (!empty($wp_request['env']) && $wp_request['env'] == 'dev') {
+      $env_add = '/dev';
+    }
+    return "https://www.yesticket.org$env_add/picture.php?event=" . $event_id;
   }
 }

--- a/yesticket/src/model/environment_aware_class.php
+++ b/yesticket/src/model/environment_aware_class.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace YesTicket\Model;
+
+/**
+ * Extend this class to add 'environment aware' capabilities to your model.
+ */
+abstract class EnvironmentAware
+{
+
+  /**
+   * @var string The environment. '' for PROD
+   */
+  private $yesticket_environment = '';
+
+  /**
+   * @return true if $this->yesticket_environment is 'dev'
+   */
+  public function isDevEnvironment() {
+    return !empty($this->yesticket_environment) && $this->yesticket_environment == 'dev';
+  }
+
+  /**
+   * Set environment for yesticket.
+   * Use '' for PROD.
+   * @param string $environment
+   * @return self
+   */
+  public function setYesticketEnvironment($environment) {
+    $this->yesticket_environment = $environment;
+    return $this;
+  }
+
+}

--- a/yesticket/src/rest/image_endpoint.php
+++ b/yesticket/src/rest/image_endpoint.php
@@ -100,14 +100,14 @@ class ImageEndpoint
   /**
    * Callback for our registered REST route
    * 
-   * @param WP_REST_Request $data
+   * @param WP_REST_Request $wp_request
    * 
    * @return WP_REST_Response
    * @return WP_Error
    */
-  public function handleRequest($data)
+  public function handleRequest($wp_request)
   {
-    $result = $this->api->getEventImage($data['event_id']);
+    $result = $this->api->getEventImage($wp_request);
     if (\is_wp_error($result)) {
       return new WP_REST_Response(null, WP_Http::TEMPORARY_REDIRECT, array('Location' => $result->get_error_data()));
     }

--- a/yesticket/tests/helpers/api-test.php
+++ b/yesticket/tests/helpers/api-test.php
@@ -106,15 +106,36 @@ class ApiTest extends WP_UnitTestCase
     $this->run_events("$base_uri?lang=de&organizer=1&key=key1", array(), '1', 'key1', 'de_DE');
     // Different organizer & key
     $this->run_events("$base_uri?lang=en&organizer=2&key=keyof2", array('organizer' => '2', 'key' => 'keyof2'), '1', 'key1', 'en_EN');
-    // env = dev
-    $this->run_events("https://www.yesticket.org/dev/api/v2/events.php?lang=en&organizer=1&key=key1", array('env' => 'dev'), '1', 'key1', 'en_EN');
     // count = 50
     $this->run_events("$base_uri?count=50&lang=en&organizer=1&key=key1", array('count' => '50'), '1', 'key1', 'en_EN');
     // type = all
     $this->run_events("$base_uri?type=all&lang=en&organizer=1&key=key1", array('type' => 'all'), '1', 'key1', 'en_EN');
     // api-version = 1
     $this->run_events("https://www.yesticket.org/api/events-endpoint.php?lang=en&organizer=1&key=key1", array('api-version' => '1'), '1', 'key1', 'en_EN');
+  }
 
+  /**
+   * @covers YesTicket\Api
+   */
+  function test_getEvents_dev()
+  {
+    $base_uri = 'https://www.yesticket.org/dev/api/v2/events.php';
+    // Generate a Mock Result
+    $evt1 = new Event(false);
+    $evt1->event_name = "My mocked event #1";
+
+    $this->prepare("$base_uri?lang=en&organizer=1&key=key1", [$evt1], '1', 'key1', 'en_EN');
+    $result = Api::getInstance()->getEvents(array('env' => 'dev'));
+    $this->assertCount(1, $result);
+    $this->assertTrue($result[0]->isDevEnvironment());
+  }
+
+  /**
+   * @covers YesTicket\Api
+   */
+  function test_getEvents_grep()
+  {
+    $base_uri = 'https://www.yesticket.org/api/v2/events.php';
     // Generate a Mock Result
     $evt1 = new Event(false);
     $evt1->event_name = "My mocked event #1";

--- a/yesticket/tests/helpers/image_api-test.php
+++ b/yesticket/tests/helpers/image_api-test.php
@@ -51,22 +51,50 @@ class ImageApiTest extends WP_UnitTestCase
    */
   function test_cache_returns_cachedImage()
   {
-    // Define our http-get endpoint
-    $get_url = "https://www.yesticket.org/picture.php?event=123";
+    // Define expected yesticket URL for image
+    $expected_url = "https://www.yesticket.org/picture.php?event=123";
     // Set up mock to return a png on 'image/png'
     $mock_result = new CachedImage();
     $cache_mock = $this->initMock();
     $cache_mock->expects($this->once())
       ->method('getFromCacheOrFresh')
       ->with(
-        $get_url,
+        $expected_url,
         $this->callback(function ($getFunction) {
           return \is_callable($getFunction);
         })
       )
       ->will($this->returnValue($mock_result));
     // Call and assert
-    $this->assertSame($mock_result, ImageApi::getInstance()->getEventImage(123));
+    $request = new WP_REST_Request();
+    $request['event_id'] = 123;
+    $this->assertSame($mock_result, ImageApi::getInstance()->getEventImage($request));
+  }
+
+  /**
+   * @covers YesTicket\ImageApi
+   */
+  function test_cache_returns_cachedImage_dev()
+  {
+    // Define expected yesticket URL for image
+    $expected_url = "https://www.yesticket.org/dev/picture.php?event=123";
+    // Set up mock to return a png on 'image/png'
+    $mock_result = new CachedImage();
+    $cache_mock = $this->initMock();
+    $cache_mock->expects($this->once())
+      ->method('getFromCacheOrFresh')
+      ->with(
+        $expected_url,
+        $this->callback(function ($getFunction) {
+          return \is_callable($getFunction);
+        })
+      )
+      ->will($this->returnValue($mock_result));
+    // Call and assert
+    $request = new WP_REST_Request();
+    $request['event_id'] = 123;
+    $request['env'] = 'dev';
+    $this->assertSame($mock_result, ImageApi::getInstance()->getEventImage($request));
   }
 
   /**
@@ -82,7 +110,9 @@ class ImageApiTest extends WP_UnitTestCase
       ->method('getFromCacheOrFresh')
       ->with($get_url)
       ->will($this->returnValue(new WP_Error(503)));
-    $result = ImageApi::getInstance()->getEventImage(123);
+    $request = new WP_REST_Request();
+    $request['event_id'] = 123;
+    $result = ImageApi::getInstance()->getEventImage($request);
     $this->assertTrue(\is_wp_error($result));
     $this->assertSame($get_url, $result->get_error_data(), "Error data should be the URL to the actual yesticket resource.");
   }
@@ -181,7 +211,9 @@ class ImageApiTest extends WP_UnitTestCase
       )
       ->will($this->returnValue(new CachedImage()));
     // Start test.
-    ImageApi::getInstance()->getEventImage($event_id);
+    $request = new WP_REST_Request();
+    $request['event_id'] = $event_id;
+    ImageApi::getInstance()->getEventImage($request);
   }
 
   /**

--- a/yesticket/tests/model/event-test.php
+++ b/yesticket/tests/model/event-test.php
@@ -96,57 +96,85 @@ class EventTest extends WP_UnitTestCase
   {
     $input = new Event(true);
     $input->event_id = 1;
+    // ENV = '' [meaning PROD]
     $this->assertSame('http://example.org/wp-json/yesticket/v1/picture/1', $input->getPictureUrl());
+    // ENV = 'dev'
+    $input->setYesticketEnvironment('dev');
+    $this->assertSame('http://example.org/wp-json/yesticket/v1/picture/1?env=dev', $input->getPictureUrl());
   }
   /**
    * @covers YesTicket\Model\Event
    */
-  function test_getPictureUrl_take_from_event_picture_url()
+  function test_getPictureUrl_no_eventId_but_pictureUrl_contains_id()
   {
     $input = new Event(true);
+    // ENV = '' [meaning PROD]
     $input->event_picture_url = 'https://www.yesticket.org/picture.php?event=69';
     $this->assertSame('http://example.org/wp-json/yesticket/v1/picture/69', $input->getPictureUrl());
+    // ENV = 'dev'
+    $input->setYesticketEnvironment('dev');
+    $input->event_picture_url = 'https://www.yesticket.org/dev/picture.php?event=69';
+    $this->assertSame('http://example.org/wp-json/yesticket/v1/picture/69?env=dev', $input->getPictureUrl());
   }
 
   /**
    * @covers YesTicket\Model\Event
    */
-  function test_getPictureUrl_null()
+  function test_getPictureUrl_no_eventId_and_pictureUrl_is_null()
   {
     $input = new Event(true);
-    $this->assertSame("https://www.yesticket.org/picture.php?event=0", $input->getPictureUrl());
+    // ENV = '' [meaning PROD]
+    $this->assertSame("http://example.org/wp-json/yesticket/v1/picture/0", $input->getPictureUrl());
+    // ENV = 'dev'
+    $input->setYesticketEnvironment('dev');
+    $this->assertSame('http://example.org/wp-json/yesticket/v1/picture/0?env=dev', $input->getPictureUrl());
   }
 
   /**
    * @covers YesTicket\Model\Event
    */
-  function test_getPictureUrl_malformed()
+  function test_getPictureUrl_no_eventId_and_pictureUrl_malformed()
   {
     $input = new Event(true);
     $input->event_picture_url = "not an url";
-    $this->assertSame("https://www.yesticket.org/picture.php?event=0", $input->getPictureUrl());
+    // ENV = '' [meaning PROD]
+    $this->assertSame("http://example.org/wp-json/yesticket/v1/picture/0", $input->getPictureUrl());
+    // ENV = 'dev'
+    $input->setYesticketEnvironment('dev');
+    $this->assertSame('http://example.org/wp-json/yesticket/v1/picture/0?env=dev', $input->getPictureUrl());
   }
 
   /**
    * @covers YesTicket\Model\Event
    */
-  function test_getPictureUrl_no_event_id_given()
+  function test_getPictureUrl_no_eventId_and_pictureUrl_contains_no_id()
   {
     $input = new Event(true);
+    // ENV = '' [meaning PROD]
     $input->event_picture_url = "https://www.yesticket.org/picture.php?not=given";
     $this->assertSame("https://www.yesticket.org/picture.php?not=given", $input->getPictureUrl());
+    // ENV = 'dev'
+    $input->setYesticketEnvironment('dev');
+    $input->event_picture_url = "https://www.yesticket.org/dev/picture.php?not=given";
+    $this->assertSame('https://www.yesticket.org/dev/picture.php?not=given', $input->getPictureUrl());
   }
 
   /**
    * @covers YesTicket\Model\Event
    */
-  function test_getPictureUrl_no_fopen_allowed()
+  function test_getPictureUrl_eventId_given_but_no_fopen_allowed()
   {
     $input = new Event(false);
     $input->event_id = 1;
+    // ENV = '' [meaning PROD]
     $input->event_picture_url = 'https://www.yesticket.org/picture.php?event=69';
-    $result =  $input->getPictureUrl();
+    $result = $input->getPictureUrl();
     $this->assertSame('https://www.yesticket.org/picture.php?event=69', $result);
+    // ENV = 'dev'
+    $input->setYesticketEnvironment('dev');
+    $input->event_picture_url = 'https://www.yesticket.org/dev/picture.php?event=69';
+    $result = $input->getPictureUrl();
+    $this->assertSame('https://www.yesticket.org/dev/picture.php?event=69', $result);
   }
 
   /**
@@ -158,7 +186,11 @@ class EventTest extends WP_UnitTestCase
     \update_option('siteurl', 'http://another-example.org/subpath');
     $input = new Event(true);
     $input->event_id = 1;
+    // ENV = '' [meaning PROD]
     $this->assertSame('http://another-example.org/subpath/wp-json/yesticket/v1/picture/1', $input->getPictureUrl());
+    // ENV = 'dev'
+    $input->setYesticketEnvironment('dev');
+    $this->assertSame('http://another-example.org/subpath/wp-json/yesticket/v1/picture/1?env=dev', $input->getPictureUrl());
     \update_option('siteurl', $oldSite);
   }
 

--- a/yesticket/tests/rest/image_endpoint-test.php
+++ b/yesticket/tests/rest/image_endpoint-test.php
@@ -87,11 +87,11 @@ class ImageEndpointTest extends WP_UnitTestCase
   {
     $mock_result = getCachedImage('image/jpeg', '\imagejpeg');
     $cache_mock = $this->initMock();
+    $request = new WP_REST_Request('GET', '/yesticket/v1/picture/123');
     $cache_mock->expects($this->once())
       ->method('getEventImage')
-      ->with(123)
+      ->with($request)
       ->will($this->returnValue($mock_result));
-    $request = new WP_REST_Request('GET', '/yesticket/v1/picture/123');
     \ob_start();
     $response = @$this->server->dispatch($request);
     $output = \ob_end_clean();
@@ -108,11 +108,11 @@ class ImageEndpointTest extends WP_UnitTestCase
   function test_handleRequest_given_exception_expect_redirect()
   {
     $cache_mock = $this->initMock();
+    $request = new WP_REST_Request('GET', '/yesticket/v1/picture/123');
     $cache_mock->expects($this->once())
       ->method('getEventImage')
-      ->with(123)
+      ->with($request)
       ->will($this->returnValue(new WP_Error(503, null, 'https://mock.response')));
-    $request = new WP_REST_Request('GET', '/yesticket/v1/picture/123');
     \ob_start();
     $response = @$this->server->dispatch($request);
     \ob_end_clean();


### PR DESCRIPTION
Fixes Trello issue 999

OLD behavior:
* images always used the yesticket prod 'picture' URL

NEW behavior:
* Given a shortcode is using a 'dev' endpoint
* That shortcode also renders images
* Cache is enabled
* The image url now contains '?env=dev', allowing the source image to be pulled from yesticket's DEV servers.